### PR TITLE
Usability changes and fixes for errors and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ Below are described the properties specific to each method (the `Name` property 
 
 * `Frame Step` (by default set to **3**) : **N** (as defined in the [Setting](#setting) section) = frequency at which the training frames are registered
 * `Camera` (always set to the active camera) : camera used for registering training and testing data
-* `PLAY SOF` : play the **Subset of Frames** method
+* `EXPORT SOF` : export using the **Subset of Frames** method
 
 ### How to TTC
 
 * `Train Cam` (empty by default) : camera used for registering the training data
 * `Test Cam` (empty by default) : camera used for registering the testing data
-* `PLAY TTC` : play the **Train and Test Cameras** method
+* `EXPORT TTC` : export using the **Train and Test Cameras** method
 
 ### How to COS
 
@@ -101,7 +101,7 @@ Below are described the properties specific to each method (the `Name` property 
 * `Camera` (deactivated by default) : whether to show the camera used for registering the training data
 * `Upper Views` (deactivated by default) : whether to sample views from the upper training hemisphere only (rotation variant)
 * `Outwards` (deactivated by default) : whether to point the camera outwards of the training sphere
-* `PLAY COS` : play the **Camera on Sphere** method
+* `EXPORT COS` : export using the **Camera on Sphere** method
 
 Note that activating the `Sphere` and `Camera` properties creates a `BlenderNeRF Sphere` empty object and a `BlenderNeRF Camera` camera object respectively. Please do not create any objects with these names manually, since this might break the add-on functionalities.
 

--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@ bl_info = {
     'name': 'BlenderNeRF',
     'description': 'Easy NeRF synthetic dataset creation within Blender',
     'author': 'Maxime Raafat',
-    'version': (4, 0, 1),
+    'version': (4, 0, 0),
     'blender': (3, 0, 0),
     'location': '3D View > N panel > BlenderNeRF',
     'doc_url': 'https://github.com/maximeraafat/BlenderNeRF',
@@ -19,11 +19,13 @@ TRAIN_CAM = 'Train Cam'
 TEST_CAM = 'Test Cam'
 VERSION = '.'.join(str(x) for x in bl_info['version'])
 
+enum_items = (('train_data','Train',''),('test_data','Test',''))
+
 # addon blender properties
 PROPS = [
     # global controllable properties
-    ('train_data', bpy.props.BoolProperty(name='Train', description='Construct the training data', default=True) ),
-    ('test_data', bpy.props.BoolProperty(name='Test', description='Construct the testing data', default=True) ),
+    ('train_test_data', bpy.props.EnumProperty(items=enum_items, name='Train or Test set', description='Whether training or test set should be exported', default='train_data') ),
+
     ('aabb', bpy.props.IntProperty(name='AABB', description='AABB scale as defined in Instant NGP', default=4, soft_min=1, soft_max=128) ),
     ('render_frames', bpy.props.BoolProperty(name='Render Frames', description='Whether training frames should be rendered. If not selected, only the transforms.json files will be generated', default=True) ),
     ('logs', bpy.props.BoolProperty(name='Save Log File', description='Whether to create a log file containing information on the BlenderNeRF run', default=False) ),
@@ -57,7 +59,7 @@ PROPS = [
     ('show_sphere', bpy.props.BoolProperty(name='Sphere', description='Whether to show the training sphere from which random views will be sampled', default=False, update=helper.visualize_sphere) ),
     ('show_camera', bpy.props.BoolProperty(name='Camera', description='Whether to show the training camera', default=False, update=helper.visualize_camera) ),
     ('upper_views', bpy.props.BoolProperty(name='Upper Views', description='Whether to sample views from the upper hemisphere of the training sphere only', default=False) ),
-    ('outwards', bpy.props.BoolProperty(name='Outwards', description='Whether to point the camera outwards of the training sphere', default=False, update=helper.properties_ui_upd) ),
+    ('outwards', bpy.props.BoolProperty(name='Outwards', description='Whether to point the camera outwards of the training sphere', default=False) ),
 
     # cos automatic properties
     ('sphere_exists', bpy.props.BoolProperty(name='Sphere Exists', description='Whether the sphere exists', default=False) ),

--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@ bl_info = {
     'name': 'BlenderNeRF',
     'description': 'Easy NeRF synthetic dataset creation within Blender',
     'author': 'Maxime Raafat',
-    'version': (4, 0, 0),
+    'version': (4, 0, 2),
     'blender': (3, 0, 0),
     'location': '3D View > N panel > BlenderNeRF',
     'doc_url': 'https://github.com/maximeraafat/BlenderNeRF',
@@ -59,7 +59,7 @@ PROPS = [
     ('show_sphere', bpy.props.BoolProperty(name='Sphere', description='Whether to show the training sphere from which random views will be sampled', default=False, update=helper.visualize_sphere) ),
     ('show_camera', bpy.props.BoolProperty(name='Camera', description='Whether to show the training camera', default=False, update=helper.visualize_camera) ),
     ('upper_views', bpy.props.BoolProperty(name='Upper Views', description='Whether to sample views from the upper hemisphere of the training sphere only', default=False) ),
-    ('outwards', bpy.props.BoolProperty(name='Outwards', description='Whether to point the camera outwards of the training sphere', default=False) ),
+    ('outwards', bpy.props.BoolProperty(name='Outwards', description='Whether to point the camera outwards of the training sphere', default=False, update=helper.properties_ui_upd) ),
 
     # cos automatic properties
     ('sphere_exists', bpy.props.BoolProperty(name='Sphere Exists', description='Whether the sphere exists', default=False) ),
@@ -112,3 +112,4 @@ def unregister():
 
 if __name__ == '__main__':
     register()
+    

--- a/blender_nerf_operator.py
+++ b/blender_nerf_operator.py
@@ -149,8 +149,8 @@ class BlenderNeRF_Operator(bpy.types.Operator):
         logdata = {
             'BlenderNeRF Version': scene.blendernerf_version,
             'Date and Time' : now.strftime("%d/%m/%Y %H:%M:%S"),
-            'Train': scene.train_data,
-            'Test': scene.test_data,
+            'Train': scene.train_test_data == "train_data",
+            'Test': scene.train_test_data == "test_data",
             'AABB': scene.aabb,
             'Render Frames': scene.render_frames,
             'File Format': 'NeRF' if scene.nerf else 'NGP',

--- a/blender_nerf_ui.py
+++ b/blender_nerf_ui.py
@@ -4,7 +4,7 @@ import bpy
 # blender nerf shared ui properties class
 class BlenderNeRF_UI(bpy.types.Panel):
     '''BlenderNeRF UI'''
-    bl_idname = 'panel.blender_nerf_ui'
+    bl_idname = 'SCENE_PT_blender_nerf_ui'
     bl_label = 'BlenderNeRF shared UI'
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
@@ -17,16 +17,15 @@ class BlenderNeRF_UI(bpy.types.Panel):
         layout.alignment = 'CENTER'
 
         row = layout.row(align=True)
-        row.prop(scene, 'train_data', toggle=True)
-        row.prop(scene, 'test_data', toggle=True)
+        row.prop(scene, 'train_test_data', expand=True)
 
-        if not (scene.train_data or scene.test_data):
+        if not (scene.train_test_data == "train_data" or scene.train_test_data == "test_data"):
             layout.label(text='Nothing will happen!')
 
         else:
             layout.prop(scene, 'aabb')
 
-            if scene.train_data:
+            if scene.train_test_data == "train_data":
                 layout.separator()
                 layout.prop(scene, 'render_frames')
 

--- a/cos_operator.py
+++ b/cos_operator.py
@@ -47,12 +47,12 @@ class CameraOnSphere(blender_nerf_operator.BlenderNeRF_Operator):
         scene.init_frame_end = scene.frame_end
         scene.init_active_camera = camera
 
-        if scene.test_data:
+        if scene.train_test_data == "test_data":
             # testing transforms
             output_data['frames'] = self.get_camera_extrinsics(scene, camera, mode='TEST', method='COS')
             self.save_json(output_path, 'transforms_test.json', output_data)
 
-        if scene.train_data:
+        if scene.train_test_data == "train_data":
             if not scene.show_camera: scene.show_camera = True
 
             # train camera on sphere

--- a/cos_ui.py
+++ b/cos_ui.py
@@ -4,7 +4,7 @@ import bpy
 # camera on sphere ui class
 class COS_UI(bpy.types.Panel):
     '''Camera on Sphere UI'''
-    bl_idname = 'panel.cos_ui'
+    bl_idname = 'SCENE_PT_cos_ui'
     bl_label = 'Camera on Sphere COS'
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
@@ -43,4 +43,4 @@ class COS_UI(bpy.types.Panel):
         layout.prop(scene, 'cos_dataset_name')
 
         layout.separator()
-        layout.operator('object.camera_on_sphere', text='PLAY COS')
+        layout.operator('object.camera_on_sphere', text='EXPORT COS')

--- a/helper.py
+++ b/helper.py
@@ -166,7 +166,7 @@ def properties_desgraph(scene):
     if CAMERA_NAME in scene.objects.keys():
         scene.objects[CAMERA_NAME].location = sample_from_sphere(scene)
 
-def empty_fn(self): pass
+def empty_fn(self, context): pass
 
 can_scene_upd = properties_ui
 can_properties_upd = properties_desgraph

--- a/sof_operator.py
+++ b/sof_operator.py
@@ -38,12 +38,12 @@ class SubsetOfFrames(blender_nerf_operator.BlenderNeRF_Operator):
         scene.init_frame_step = scene.frame_step
         scene.init_output_path = scene.render.filepath
 
-        if scene.test_data:
+        if scene.train_test_data == "test_data":
             # testing transforms
             output_data['frames'] = self.get_camera_extrinsics(scene, camera, mode='TEST', method='SOF')
             self.save_json(output_path, 'transforms_test.json', output_data)
 
-        if scene.train_data:
+        if scene.train_test_data == "train_data":
             # training transforms
             output_data['frames'] = self.get_camera_extrinsics(scene, camera, mode='TRAIN', method='SOF')
             self.save_json(output_path, 'transforms_train.json', output_data)

--- a/sof_ui.py
+++ b/sof_ui.py
@@ -4,7 +4,7 @@ import bpy
 # subset of frames ui class
 class SOF_UI(bpy.types.Panel):
     '''Subset of Frames UI'''
-    bl_idname = 'panel.sof_ui'
+    bl_idname = 'SCENE_PT_sof_ui'
     bl_label = 'Subset of Frames SOF'
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
@@ -26,4 +26,4 @@ class SOF_UI(bpy.types.Panel):
         layout.prop(scene, 'sof_dataset_name')
 
         layout.separator()
-        layout.operator('object.subset_of_frames', text='PLAY SOF')
+        layout.operator('object.subset_of_frames', text='EXPORT SOF')

--- a/ttc_operator.py
+++ b/ttc_operator.py
@@ -39,12 +39,12 @@ class TrainTestCameras(blender_nerf_operator.BlenderNeRF_Operator):
         # initial property might have changed since set_init_props update
         scene.init_output_path = scene.render.filepath
 
-        if scene.test_data:
+        if scene.train_test_data == "test_data":
             # testing transforms
             output_test_data['frames'] = self.get_camera_extrinsics(scene, test_camera, mode='TEST', method='TTC')
             self.save_json(output_path, 'transforms_test.json', output_test_data)
 
-        if scene.train_data:
+        if scene.train_test_data == "train_data":
             # training transforms
             output_train_data['frames'] = self.get_camera_extrinsics(scene, train_camera, mode='TRAIN', method='TTC')
             self.save_json(output_path, 'transforms_train.json', output_train_data)

--- a/ttc_ui.py
+++ b/ttc_ui.py
@@ -4,7 +4,7 @@ import bpy
 # train and test cameras ui class
 class TTC_UI(bpy.types.Panel):
     '''Train and Test Cameras UI'''
-    bl_idname = 'panel.ttc_ui'
+    bl_idname = 'SCENE_PT_ttc_ui'
     bl_label = 'Train and Test Cameras TTC'
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
@@ -25,4 +25,4 @@ class TTC_UI(bpy.types.Panel):
         layout.prop(scene, 'ttc_dataset_name')
 
         layout.separator()
-        layout.operator('object.train_test_cameras', text='PLAY TTC')
+        layout.operator('object.train_test_cameras', text='EXPORT TTC')


### PR DESCRIPTION
Hi @maximeraafat,

First of all thank you very much for providing this addon! I speeds up the process of creating datasets tremendously and I have successfully tested it with InstantNGP.

During my tests, I have noticed some issues regarding usablity and therefore propose the following changes in this PR:

- [x]  Changed "Train" and "Test" buttons to an EnumProperty (Radio buttons) in order to allow the selection of either training or testing set generation. I did this due to the missing functionality to export testing images. But now after implementing this, I saw that this seems to be intended behaviour, right?
- [x]  Fixed error when  when 'empty_fn' was assigned to 'properties_ui_upd(self, context)' in 'helper.py' - it expected two arguments (self and context)
- [x]  Fixed warning by renam in ui panel 'idname' to include '_PT_' and only consist of alphanumeric values (i.e. removed '.').
- [x]  Furthermore renamed 'PLAY {MOTION-OPERATOR}' to 'EXPORT {MOTION-OPERATOR}' for the different panel user interfaces for "COS", "SOF" and "TTC".

Regarding the first point with the introduction of a new enumProperty, I am not sure if my fix is to your liking. I suspect that I misunderstood the usage of the addon here, since with my fixes it is NOT possible to include both Training and Testing datasets but they are mutually exclusive now. A user would need to unzip the "dataset.zip" file now and merge both files. Furthermore, I noticed that you are not rendering the test images - is there a reason for this?

I would appreciate if you could take a look at my suggestions and cherrypick the ones you like or simply decline this pull request if you don't agree with them.

Thank you and kind regards,
Adam