### PR TITLE
Cameras on Sphere: fix randomness bugs

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -90,7 +90,7 @@ def sample_from_sphere(scene):
 
     # sample random angles
     theta = random.random() * 2 * math.pi
-    phi = random.random() * 2 * math.pi
+    phi = math.acos(1. - 2. * random.random())
 
     # uniform sample from unit sphere, given theta and phi
     unit_x = math.cos(theta) * math.sin(phi)

--- a/helper.py
+++ b/helper.py
@@ -85,12 +85,12 @@ def delete_camera(scene, name):
 
 # non uniform sampling when stretched or squeezed sphere
 def sample_from_sphere(scene):
-    # (2 * seed + 1) * (time + 1) to avoid recurring sample for seed = 0 or time = 0
-    random.seed( (2 * scene.seed + 1) * (scene.frame_current + 1) )
+    seed = (2654435761 * (scene.seed + 1)) ^ (805459861 * (scene.frame_current + 1))
+    rng = random.Random(seed)
 
     # sample random angles
-    theta = random.random() * 2 * math.pi
-    phi = math.acos(1. - 2. * random.random())
+    theta = rng.random() * 2 * math.pi
+    phi = math.acos(1. - 2. * rng.random())
 
     # uniform sample from unit sphere, given theta and phi
     unit_x = math.cos(theta) * math.sin(phi)


### PR DESCRIPTION
Hello @maximeraafat,

Thank you for creating this add-on which makes generating synthetic datasets much easier.
With this pull request, we hope to fix two bugs which we have encountered.

### 1. Distribution of cameras on the sphere

The camera positions are not uniformly distributed on the sphere (as claimed by the comments), but biased towards the poles.

Without this PR:
![origins-clumped](https://github.com/user-attachments/assets/0480b7fa-bb09-4ab0-aa53-cfd55359d954)

With this PR:
![origins-fixed](https://github.com/user-attachments/assets/b38eaa8e-f90e-404a-8b35-e125acd34a3c)

This issue was discovered and fixed by @nmwsharp.

### 2. Seed reuse

When a user provides a seed to a random number generator, they expect fully distinct sequences of random numbers regardless of how close the two seeds are from each other.
Unfortunately, the way that `scene.seed` and `scene.frame_current` are combined breaks this property.

For example, generating 10 COS frames with seed 0, then seed 1 will lead to:
- 0005 and 0001 being identical
- 0008 and 0002 being identical

I changed the way the effective seed is computed and also switched to using a local `random.Random()` object in order to avoid affecting the global RNG seed.